### PR TITLE
fix typo

### DIFF
--- a/poetry-ja/cli/index.html
+++ b/poetry-ja/cli/index.html
@@ -1026,7 +1026,7 @@
                 <h1 id="_1">コマンド<a class="headerlink" href="#_1" title="Permanent link">🔗</a></h1>
 <p>これまでに、何かをするためのコマンドラインインターフェースの使い方を学びました。
 この章では、全ての利用可能なコマンドについて記述します。</p>
-<p>コマントラインでヘルプを出すには、 <code>poetry</code> と呼び出すとコマンドの完全なリストが見られて、コマンドのどれかに <code>--help</code>
+<p>コマンドラインでヘルプを出すには、 <code>poetry</code> と呼び出すとコマンドの完全なリストが見られて、コマンドのどれかに <code>--help</code>
 を付けて実行するとより詳しい情報が得られます。</p>
 <h2 id="_2">グローバルオプション<a class="headerlink" href="#_2" title="Permanent link">🔗</a></h2>
 <ul>


### PR DESCRIPTION
### WHAT 
I found a typo and fixed it.

`コマントライン`->`コマンドライン`